### PR TITLE
Add hyper::Uri support 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ doctest = false
 
 [dependencies]
 cookie = {version = "0.6", default-features = false}
+# "raw_status" feature needed to expose the RawStatus type from hyper
 hyper = { version = "0.11", features = ["raw_status"] }
 mime = "0.3"
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ doctest = false
 
 [dependencies]
 cookie = {version = "0.6", default-features = false}
-hyper = "0.10"
-mime = "0.2"
+hyper = { version = "0.11", features = ["raw_status"] }
+mime = "0.3"
 serde = "1.0"
 serde_bytes = "0.10"
 time = "0.1"
@@ -26,3 +26,6 @@ time = "0.1"
 [dev-dependencies]
 serde_test = "1.0"
 time = "0.1"
+
+[replace]
+"hyper:0.11.2" = { git = "https://github.com/hyperium/hyper.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper_serde"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["Anthony Ramine <n.oxyde@gmail.com>"]
 description = "Serde support for Hyper types"
 license = "MIT/Apache-2.0"
@@ -16,7 +16,7 @@ travis-ci = { repository = "nox/hyper_serde" }
 doctest = false
 
 [dependencies]
-cookie = {version = "0.6", default-features = false}
+cookie = {version = "0.10", default-features = false}
 # "raw_status" feature needed to expose the RawStatus type from hyper
 hyper = { version = "0.11", features = ["raw_status"] }
 mime = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,3 @@ time = "0.1"
 [dev-dependencies]
 serde_test = "1.0"
 time = "0.1"
-
-[replace]
-"hyper:0.11.2" = { git = "https://github.com/hyperium/hyper.git" }

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The supported types are:
 * `hyper::header::Headers`
 * `hyper::http::RawStatus`
 * `hyper::method::Method`
+* `hyper::Uri`
 * `mime::Mime`
 * `time::Tm`
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ The supported types are:
 * `cookie::Cookie`
 * `hyper::header::ContentType`
 * `hyper::header::Headers`
-* `hyper::http::RawStatus`
-* `hyper::method::Method`
+* `hyper::RawStatus`
+* `hyper::Method`
 * `hyper::Uri`
 * `mime::Mime`
 * `time::Tm`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@
 //! * `cookie::Cookie`
 //! * `hyper::header::ContentType`
 //! * `hyper::header::Headers`
-//! * `hyper::http::RawStatus`
-//! * `hyper::method::Method`
+//! * `hyper::RawStatus`
+//! * `hyper::Method`
 //! * `mime::Mime`
 //! * `time::Tm`
 //!
@@ -62,8 +62,8 @@ extern crate time;
 
 use cookie::Cookie;
 use hyper::header::{ContentType, Headers};
-use hyper::http::RawStatus;
-use hyper::method::Method;
+use hyper::RawStatus;
+use hyper::Method;
 use mime::Mime;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_bytes::{ByteBuf, Bytes};
@@ -412,7 +412,7 @@ impl<'a> Serialize for Ser<'a, Headers> {
         for header in self.v.iter() {
             let name = header.name();
             let value = self.v.get_raw(name).unwrap();
-            serializer.serialize_entry(name, &Value(value, self.pretty))?;
+            serializer.serialize_entry(name, &Value(&value.iter().map(|v| v.to_vec()).collect::<Vec<Vec<u8>>>(), self.pretty))?;
         }
         serializer.end()
     }
@@ -466,7 +466,7 @@ impl<'de> Deserialize<'de> for De<Mime> {
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
                 where E: de::Error,
             {
-                v.parse::<Mime>().map(De::new).map_err(|()| {
+                v.parse::<Mime>().map(De::new).map_err(|_| {
                     E::custom("could not parse mime type")
                 })
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 //! * `hyper::header::Headers`
 //! * `hyper::RawStatus`
 //! * `hyper::Method`
+//! * `hyper::Uri`
 //! * `mime::Mime`
 //! * `time::Tm`
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,7 +390,7 @@ impl<'a> Serialize for Ser<'a, Headers> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: Serializer,
     {
-        struct Value<'headers>(&'headers [Vec<u8>], bool);
+        struct Value<'headers>(&'headers [&'headers [u8]], bool);
 
         impl<'headers> Serialize for Value<'headers> {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -415,7 +415,13 @@ impl<'a> Serialize for Ser<'a, Headers> {
         for header in self.v.iter() {
             let name = header.name();
             let value = self.v.get_raw(name).unwrap();
-            serializer.serialize_entry(name, &Value(&value.iter().map(|v| v.to_vec()).collect::<Vec<Vec<u8>>>(), self.pretty))?;
+            serializer.serialize_entry(
+                name,
+                &Value(
+                    &value.iter().collect::<Vec<_>>(),
+                    self.pretty
+                )
+            )?;
         }
         serializer.end()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -574,6 +574,6 @@ impl<'a> Serialize for Ser<'a, Uri> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: Serializer,
     {
-        serializer.serialize_str(&self.v.to_string())
+        serializer.serialize_str(self.v.as_ref())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -564,7 +564,7 @@ impl<'de> Deserialize<'de> for De<Uri> {
     }
 }
 
-impl<'a, 'cookie> Serialize for Ser<'a, Uri> {
+impl<'a> Serialize for Ser<'a, Uri> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: Serializer,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -562,7 +562,7 @@ impl<'de> Deserialize<'de> for De<Uri> {
             {
                 Uri::from_str(v)
                     .map(De::new)
-                    .map_err(|e| E::custom(format!("{:?}", e)))
+                    .map_err(|e| E::custom(format!("{}", e)))
             }
         }
 

--- a/tests/supported.rs
+++ b/tests/supported.rs
@@ -9,6 +9,7 @@ use cookie::Cookie;
 use hyper::header::{ContentType, Headers};
 use hyper::RawStatus;
 use hyper::Method;
+use hyper::Uri;
 use hyper_serde::{De, Ser, Serde};
 use mime::Mime;
 use serde::{Deserialize, Serialize};
@@ -30,4 +31,5 @@ fn supported() {
     is_supported::<Mime>();
     is_supported::<RawStatus>();
     is_supported::<Tm>();
+    is_supported::<Uri>();
 }

--- a/tests/supported.rs
+++ b/tests/supported.rs
@@ -7,8 +7,8 @@ extern crate time;
 
 use cookie::Cookie;
 use hyper::header::{ContentType, Headers};
-use hyper::http::RawStatus;
-use hyper::method::Method;
+use hyper::RawStatus;
+use hyper::Method;
 use hyper_serde::{De, Ser, Serde};
 use mime::Mime;
 use serde::{Deserialize, Serialize};

--- a/tests/tokens.rs
+++ b/tests/tokens.rs
@@ -1,16 +1,14 @@
 extern crate cookie;
 extern crate hyper;
 extern crate hyper_serde;
-#[macro_use]
-extern crate mime;
 extern crate serde;
 extern crate serde_test;
 extern crate time;
 
 use cookie::Cookie;
 use hyper::header::{ContentType, Headers};
-use hyper::http::RawStatus;
-use hyper::method::Method;
+use hyper::RawStatus;
+use hyper::Method;
 use hyper_serde::{De, Ser, deserialize};
 use serde::Deserialize;
 use serde_test::{Deserializer, Token, assert_ser_tokens};
@@ -19,7 +17,7 @@ use time::Duration;
 
 #[test]
 fn test_content_type() {
-    let content_type = ContentType(mime!(Application / Json));
+    let content_type = ContentType("Application/Json".parse().unwrap());
     let tokens = &[Token::Str("application/json")];
 
     assert_ser_tokens(&Ser::new(&content_type), tokens);
@@ -58,10 +56,10 @@ fn test_headers_not_empty() {
     use hyper::header::Host;
 
     let mut headers = Headers::new();
-    headers.set(Host {
-        hostname: "baguette".to_owned(),
-        port: None,
-    });
+    headers.set(Host::new(
+        "baguette",
+        None
+    ));
 
     // In Hyper 0.9, Headers is internally a HashMap and thus testing this
     // with multiple headers is non-deterministic.

--- a/tests/tokens.rs
+++ b/tests/tokens.rs
@@ -9,6 +9,7 @@ use cookie::Cookie;
 use hyper::header::{ContentType, Headers};
 use hyper::RawStatus;
 use hyper::Method;
+use hyper::Uri;
 use hyper_serde::{De, Ser, deserialize};
 use serde::Deserialize;
 use serde_test::{Deserializer, Token, assert_ser_tokens};
@@ -117,6 +118,18 @@ fn test_tm() {
 
     assert_ser_tokens(&Ser::new(&time), tokens);
     assert_de_tokens(&time, tokens);
+}
+
+#[test]
+fn test_uri() {
+    use std::str::FromStr;
+
+    let uri_string = "abc://username:password@example.com:123/path/data?key=value&key2=value2#fragid1";
+    let uri = Uri::from_str(uri_string).unwrap();
+    let tokens = &[Token::Str(uri_string)];
+
+    assert_ser_tokens(&Ser::new(&uri), tokens);
+    assert_de_tokens(&uri, tokens);
 }
 
 pub fn assert_de_tokens<T>(value: &T, tokens: &[Token])


### PR DESCRIPTION
Based on PR #20 && #21, modified with feedback.

I also will make another PR for updating to hyper 0.12, but I think we can land this separately so there's a commit / release that supports hyper 0.11.