### PR TITLE
Upgrade to hyper 0.14 and add support for `hyper::Uri`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ doctest = false
 
 [dependencies]
 cookie = {version = "0.11", default-features = false}
-http = "0.1"
-hyper = { version = "0.12" }
+http = "0.2"
+hyper = "0.14"
 mime = "0.3"
 serde = "1.0"
 serde_bytes = "0.11"
@@ -29,4 +29,3 @@ headers = "0.2"
 [dev-dependencies]
 serde_test = "1.0"
 time = "0.1"
-

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The supported types are:
 * `hyper::header::Headers`
 * `hyper::http::RawStatus`
 * `hyper::method::Method`
+* `hyper::Uri`
 * `mime::Mime`
 * `time::Tm`
 

--- a/tests/supported.rs
+++ b/tests/supported.rs
@@ -10,7 +10,7 @@ extern crate time;
 use cookie::Cookie;
 use http::header::HeaderMap;
 use headers::ContentType;
-use hyper::{Method, StatusCode};
+use hyper::{Method, StatusCode, Uri};
 use hyper_serde::{De, Ser, Serde};
 use mime::Mime;
 use serde::{Deserialize, Serialize};
@@ -32,4 +32,5 @@ fn supported() {
     is_supported::<Mime>();
     is_supported::<StatusCode>();
     is_supported::<Tm>();
+    is_supported::<Uri>();
 }

--- a/tests/tokens.rs
+++ b/tests/tokens.rs
@@ -12,7 +12,7 @@ use cookie::Cookie;
 use http::header::{self, HeaderMap, HeaderValue};
 use headers::ContentType;
 use http::StatusCode;
-use hyper::Method;
+use hyper::{Method, Uri};
 use hyper_serde::{De, Ser, deserialize};
 use serde::Deserialize;
 use serde_test::{Deserializer, Token, assert_ser_tokens};
@@ -113,6 +113,19 @@ fn test_tm() {
 
     assert_ser_tokens(&Ser::new(&time), tokens);
     assert_de_tokens(&time, tokens);
+}
+
+#[test]
+fn test_uri() {
+    use std::str::FromStr;
+
+    // Note that fragment is not serialized / deserialized
+    let uri_string = "abc://username:password@example.com:123/path/data?key=value&key2=value2";
+    let uri = Uri::from_str(uri_string).unwrap();
+    let tokens = &[Token::Str(uri_string)];
+
+    assert_ser_tokens(&Ser::new(&uri), tokens);
+    assert_de_tokens(&uri, tokens);
 }
 
 pub fn assert_de_tokens<T>(value: &T, tokens: &[Token])


### PR DESCRIPTION
# Upgrade to latest version of dependencies 

Hyper 0.14 was released with support for tokio 1.x, and the other dependencies
need to upgrade to match.

# Support hyper::Uri

Credit for this implementation should go to @ferranpujolcamins and @DarrenTsung.
There have been a few PRs to try and get this functionality added to hyper_serde
over the years, and the git history is scattered. I have condensed the changes
into one commit to try and make the diff easier to review/approve.
