### PR TITLE
Update cookie to 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper_serde"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2018"
 authors = ["Anthony Ramine <n.oxyde@gmail.com>"]
 description = "Serde support for hyper types."
@@ -14,7 +14,7 @@ keywords = ["serde", "serialization", "hyper", "cookie", "mime"]
 doctest = false
 
 [dependencies]
-cookie = { version = "0.12", default-features = false }
+cookie = { version = "0.16", default-features = false }
 headers = "0.3"
 http = "0.2"
 hyper = "0.14"

--- a/tests/tokens.rs
+++ b/tests/tokens.rs
@@ -8,14 +8,13 @@ extern crate serde;
 extern crate serde_test;
 extern crate time;
 
-use cookie::Cookie;
-use http::header::{self, HeaderMap, HeaderValue};
+use cookie::{time::Duration, Cookie};
 use headers::ContentType;
+use http::header::{self, HeaderMap, HeaderValue};
 use http::StatusCode;
 use hyper::{Method, Uri};
 use hyper_serde::{De, Ser};
 use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
-use time::Duration;
 
 #[test]
 fn test_content_type() {


### PR DESCRIPTION
This crate is the only external one preventing Servo from deduplicating the cookie one by moving to cookie 0.16 which is already used by `webdriver 0.48`