### PR TITLE
Update cookie to 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["serde", "serialization", "hyper", "cookie", "mime"]
 doctest = false
 
 [dependencies]
-cookie = { version = "0.16", default-features = false }
+cookie = { version = "0.18", default-features = false }
 headers = "0.3"
 http = "0.2"
 hyper = "0.14"

--- a/tests/tokens.rs
+++ b/tests/tokens.rs
@@ -30,13 +30,13 @@ fn test_cookie() {
     // Unfortunately we have to do the to_string().parse() dance here to avoid the object being a
     // string with a bunch of indices in it which apparently is different from the exact same
     // cookie but parsed as a bunch of strings.
-    let cookie: Cookie = Cookie::build("Hello", "World!")
+    let cookie: Cookie = Cookie::build(("Hello", "World!"))
         .max_age(Duration::seconds(42))
         .domain("servo.org")
         .path("/")
         .secure(true)
         .http_only(false)
-        .finish().to_string().parse().unwrap();
+        .to_string().parse().unwrap();
 
     let tokens = &[Token::Str("Hello=World!; Secure; Path=/; Domain=servo.org; Max-Age=42")];
 


### PR DESCRIPTION
This crate is the only external one preventing Servo from deduplicating the cookie one.